### PR TITLE
Gotcha added to bottom of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,18 @@ const privKey = "2442e1526f1..."; // raw private key
 const w = new WalletProvider(privKey, "https://ropsten.infura.io/MY_INFURA_KEY")
 web3 = new Web3(w.engine)
 ```
+
+## Bugs
+
+Occasionally this will randomly happen:
+
+```
+var sig = secp256k1.sign(msgHash, privateKey)
+                      ^
+
+TypeError: private key should be a Buffer
+    at Object.exports.ecsign (.../node_modules/ethereumjs-tx/node_modules/ethereumjs-util/index.js:328:23)
+    at Transaction.sign (.../node_modules/ethereumjs-tx/es5/index.js:252:23)
+```
+
+But trying again will usually fix it. Not sure why this only happens occasionally.

--- a/README.md
+++ b/README.md
@@ -65,17 +65,11 @@ const w = new WalletProvider(privKey, "https://ropsten.infura.io/MY_INFURA_KEY")
 web3 = new Web3(w.engine)
 ```
 
-## Bugs
+## Notes
 
-Occasionally this will randomly happen:
+Make sure the `from` address you use when sending transactions is entirely lowercase or you will see an error like this:
 
 ```
-var sig = secp256k1.sign(msgHash, privateKey)
-                      ^
-
 TypeError: private key should be a Buffer
-    at Object.exports.ecsign (.../node_modules/ethereumjs-tx/node_modules/ethereumjs-util/index.js:328:23)
-    at Transaction.sign (.../node_modules/ethereumjs-tx/es5/index.js:252:23)
 ```
 
-But trying again will usually fix it. Not sure why this only happens occasionally.


### PR DESCRIPTION
Submitting this as a PR since I can't raise an issue on the fork. Would be good to have this as its own repo since it does something different to the one it was forked off of.

Occasionally this will randomly happen:

```
var sig = secp256k1.sign(msgHash, privateKey)
                      ^

TypeError: private key should be a Buffer
    at Object.exports.ecsign (.../node_modules/ethereumjs-tx/node_modules/ethereumjs-util/index.js:328:23)
    at Transaction.sign (.../node_modules/ethereumjs-tx/es5/index.js:252:23)
```

But trying again will usually fix it. Not sure why this only happens occasionally.